### PR TITLE
Initialize UMBsegments

### DIFF
--- a/src/UMB.ASM
+++ b/src/UMB.ASM
@@ -31,7 +31,7 @@ UMBMCB ends
 
 .text$01 SEGMENT
 
-UMBsegments UMBBLK UMB_MAX_BLOCKS dup (<>)
+UMBsegments UMBBLK UMB_MAX_BLOCKS dup (<0,0>)
 UMBend  label byte
 
 .text$01 ends


### PR DESCRIPTION
If UMB.ASM gets assembled by JWasm under DOS (renamed from JWasmd.exe), the contents of UMBsegments is literally undefined instead of zero in JEMM32.BIN. This can cause a couple of garbage UMB entries, which get handed out to DOS. This will crash the system as soon as DOS uses the random memory addresses and sizes as UMBs.